### PR TITLE
Reset to valid.

### DIFF
--- a/includes/generate-zip.job.inc
+++ b/includes/generate-zip.job.inc
@@ -292,7 +292,7 @@ class IslandoraZipDownloadZipIterator implements RecursiveIterator {
    *   An array of PIDs to exclude from iteration. Descendents will also be
    *   excluded (unless they can be accessed via another ancestor entailed from
    *   $start).
-   * @param IslandoraZipDonwloadZipIterator|NULL $parent
+   * @param IslandoraZipDownloadZipIterator|NULL $parent
    *   Either the parent iterator (to help build out the full directory path),
    *   or NULL if we are the initial/root iterator.
    */


### PR DESCRIPTION
Resetting to zero would allow the first object to be used, despite possibly being invalid (due to being excluded).