### PR TITLE
Multiple fixes.

### DIFF
--- a/includes/generate-zip.job.inc
+++ b/includes/generate-zip.job.inc
@@ -437,7 +437,7 @@ class IslandoraZipDownloadZipIterator implements RecursiveIterator {
    * Inherits.
    */
   public function rewind() {
-    for ($this->offset = 0; $this->offset < $this->total; $this->offset++) {
+    for ($this->offset = 0; $this->offset < $this->total; $this->offset += 1) {
       if ($this->valid()) {
         break;
       }


### PR DESCRIPTION
* Reduce paths to basenames in the reassembly scripts (whoops)
* Be more specific when reassembling on *nixes
* Use unique (UUID) archive name for output
* Ensure the reassemble.sh is downloadable (gets blocked by Drupal
.htaccess stuff by default)