### PR TITLE
Primary key cannot be NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ service gearman-workers stop
 service gearman-workers start
 ```
 
+If the above returns an error of the type `Failed to stop gearman-workers.service: Unit gearman-workers.service not loaded`, you may want to try the following command instead (might require `sudo`):
+
+```
+service gearman-job-server restart
+```
+
+To check that the workers have correctly registered the new module, run
+
+```
+gearadmin --status
+```
+and look for `izd-gz` on the list of available worker functions.
+
 Depending on the final configuration, it may be necessary to install at least [version 1.11.0 of the "zip" extension](https://pecl.php.net/package-changelog.php?package=zip), in order to obtain ZIP64 support, to support large file sizes.
 
 ## Configuration

--- a/islandora_zip_download.install
+++ b/islandora_zip_download.install
@@ -33,6 +33,7 @@ function islandora_zip_download_schema() {
         'description' => 'The directory being tracked.',
         'type' => 'varchar',
         'length' => 128,
+        'not null' => TRUE,
       ),
       'created' => array(
         'description' => 'Approximate start time of generation.',


### PR DESCRIPTION
When enabling this module on a MySQL setup, we get the following error:
```
WD php: PDOException: SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a PRIMARY KEY 
must be NOT NULL; if you need NULL in a key, use UNIQUE instead: 
CREATE TABLE {islandora_zip_download_tracking} (
`path` VARCHAR(128) DEFAULT NULL COMMENT 'The directory being tracked.', 
`created` INT unsigned NOT NULL COMMENT 'Approximate start time of generation.', 
`expiry` INT unsigned NULL DEFAULT NULL COMMENT 'Expiration time.', 
PRIMARY KEY (`path`), 
INDEX `generation_started` (`created`), 
INDEX `generation_expiry` (`expiry`)
) ENGINE = InnoDB DEFAULT CHARACTER SET utf8; Array
(
)
 in db_create_table() (line 2776 of /var/www/drupal7/includes/database/database.inc).
```

By declaring the `path` column to be `NOT NULL`, this resolves the problem and the table can be created.